### PR TITLE
About codenames and new information

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 7280_WINDOWS_CLS | Snapdragon 7c+ gen 3 (SC7280 for Windows) | Qualcomm Reference Clamshell (CLS) Laptop design with SC7280 for Windows | Kodiak | Yupik |
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
 | 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
-| 8380_CRD    | Snapdragon X Elite/Plus | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE/X1P-64-100 (12c/10c) | Hamoa | |
-| 8380PA_CRD  | Snapdragon "8cx Next Gen" | Compute Reference Design (CRD) with X1P-4x-100/X12-4100 (8c) | Purwa | |
+| 8380_CRD    | Snapdragon X Elite/Plus | Compute Reference Design (CRD) with SC8380XP/SC8380XP v2 (12c/10c) | Hamoa | |
+| 8380PA_CRD  | Snapdragon "8cx Next Gen" | Compute Reference Design (CRD) with X1P-4x-100 (8c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 7280_WINDOWS_CLS | Snapdragon 7c+ gen 3 (SC7280 for Windows) | Qualcomm Reference Clamshell (CLS) Laptop design with SC7280 for Windows | Kodiak | Yupik |
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
 | 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
-| 8380_CRD    | Snapdragon X Elite | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE (12c) | Hamoa | |
+| 8380_CRD    | Snapdragon X Elite / Plus | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE/X1P-64-100 (12c/10c) | Hamoa | |
 | 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-4x-100/X12-4100 (8c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 7280_WINDOWS_CLS | Snapdragon 7c+ gen 3 (SC7280 for Windows) | Qualcomm Reference Clamshell (CLS) Laptop design with SC7280 for Windows | Kodiak | Yupik |
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
 | 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
-| 8380_CRD    | Snapdragon X Elite / Plus | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE/X1P-64-100 (12c/10c) | Hamoa | |
-| 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-4x-100/X12-4100 (8c) | Purwa | |
+| 8380_CRD    | Snapdragon X Elite/Plus | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE/X1P-64-100 (12c/10c) | Hamoa | |
+| 8380PA_CRD  | Snapdragon "8cx Next Gen" | Compute Reference Design (CRD) with X1P-4x-100/X12-4100 (8c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
 | 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
 | 8380_CRD    | Snapdragon X Elite | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE (12c) | Hamoa | |
-| 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-64/42-100 (10c) | Purwa | |
+| 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-4x-100/X12-4100 (8c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
 | 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
 | 8380_CRD    | Snapdragon X Elite | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE (12c) | Hamoa | |
-| 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-xx-100 (10c) | Purwa | |
+| 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-64/42-100 (10c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 7280_CLS    | Snapdragon 7c+ gen 3 pre-release silicon (SC7280) | Qualcomm Reference Clamshell (CLS) Laptop design with SC7280 pre-release silicon | Kodiak | Yupik |
 | 7280_WINDOWS_CLS | Snapdragon 7c+ gen 3 (SC7280 for Windows) | Qualcomm Reference Clamshell (CLS) Laptop design with SC7280 for Windows | Kodiak | Yupik |
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
-| 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Clamshell reference design (QRD) with SC8280X | Makena | |
-| 8380_CRD    | Snapdragon X Elite/Plus | Qualcomm Clamshell reference design (CRD) with SC8380XP (10c or 12c) | Hamoa | |
-| 8380PA_CRD  | Snapdragon "8cx Next Gen" / X | Qualcomm Clamshell reference design (CRD) with SC8380XP (8c) | Purwa | |
+| 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
+| 8380_CRD    | Snapdragon X Elite | Compute Reference Design (CRD) with X1E-78/80/84-100/X1E-00-1DE (12c) | Hamoa | |
+| 8380PA_CRD  | Snapdragon X Plus | Compute Reference Design (CRD) with X1P-xx-100 (10c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ These are drivers published on Windows Update for various Qualcomm Reference Lap
 | 7280_WINDOWS_CLS | Snapdragon 7c+ gen 3 (SC7280 for Windows) | Qualcomm Reference Clamshell (CLS) Laptop design with SC7280 for Windows | Kodiak | Yupik |
 | 8180_CLS    | Snapdragon 8c/8cx gen1/8cx gen2 (SC8180X/SC8180XP) | Qualcomm/Asus "Primus" Reference Clamshell (CLS) Laptop design with SC8180X/SC8180XP | Poipu | Shrike |
 | 8280_QRD    | Snapdragon 8cx gen 3 (SC8280X) | Qualcomm Reference Design (QRD) with SC8280X | Makena | |
-| 8380_CRD    | Snapdragon X Elite/Plus | Compute Reference Design (CRD) with SC8380XP/SC8380XP v2 (12c/10c) | Hamoa | |
-| 8380PA_CRD  | Snapdragon "8cx Next Gen" | Compute Reference Design (CRD) with X1P-4x-100 (8c) | Purwa | |
+| 8380_CRD    | Snapdragon X Elite/Plus | Compute Reference Design (CRD) with SC8380XP (10c or 12c) | Hamoa | |
+| 8380PA_CRD  | Snapdragon "8cx Next Gen" | Compute Reference Design (CRD) with SC8380XP (8c) | Purwa | |
 
 NOTE: __Some of the target device information are educated guesses from publicly available knowledge and may be wrong or slightly off__
 


### PR DESCRIPTION
Ah ha, Qualcomm's hardware data makes it clear that the reference design of the SC8280XP platform is called CRD8280X, but Qualcomm defines this device as QRD8280X in the software, I prefer the name QRD8280X defined in the software, so I will not change it.
The full name of QRD is Qualcomm Reference Design and the full name of CRD is Compute Reference Design.
In addition, I have confirmed that the corresponding product of Purwa is X Plus, which is not the next generation product, so I have corrected it.
Also, thank you for your contribution to the WOA driver, which has been convenient for many people, including me.